### PR TITLE
Moved Mockito to test dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ buildscript {
 dependencies {
   compile 'org.apache.httpcomponents:httpcore:4.4.4'
   compile 'org.apache.httpcomponents:httpclient:4.5.2'
-  compile 'org.mockito:mockito-core:1.10.19'
+  testCompile 'org.mockito:mockito-core:1.10.19'
   testCompile group: 'junit', name: 'junit-dep', version: '4.10'
 
 }


### PR DESCRIPTION
As referenced by this [issue](https://github.com/sendgrid/java-http-client/issues/18), Mockito should be scoped as a test dependency.

Presently we have to exclude this dependency to use the Sendgride Java Client.