### PR TITLE
change scope of mockito-core dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ buildscript {
 dependencies {
   compile 'org.apache.httpcomponents:httpcore:4.4.4'
   compile 'org.apache.httpcomponents:httpclient:4.5.2'
-  compile 'org.mockito:mockito-core:1.10.19'
+  testCompile 'org.mockito:mockito-core:1.10.19'
   testCompile group: 'junit', name: 'junit-dep', version: '4.10'
 
 }


### PR DESCRIPTION
This PR fixes #18.
It changes `mockito-core` scope (in Gradle build script) from `compile` to `testCompile`.

Thank you! 