### PR TITLE
feat: Add close method to Client

### DIFF
--- a/src/main/java/com/sendgrid/Client.java
+++ b/src/main/java/com/sendgrid/Client.java
@@ -1,5 +1,6 @@
 package com.sendgrid;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -44,7 +45,7 @@ class HttpDeleteWithBody extends HttpEntityEnclosingRequestBase {
 /**
  * Class Client allows for quick and easy access any REST or REST-like API.
  */
-public class Client {
+public class Client implements Closeable {
 
 	private CloseableHttpClient httpClient;
 	private Boolean test;
@@ -327,9 +328,14 @@ public class Client {
 	}
 
 	@Override
+	public void close() throws IOException {
+		this.httpClient.close();
+	}
+
+	@Override
 	public void finalize() throws Throwable {
 		try {
-			this.httpClient.close();
+			close();
 		} catch(IOException e) {
 			throw new Throwable(e.getMessage());
 		} finally {

--- a/src/main/java/com/sendgrid/Client.java
+++ b/src/main/java/com/sendgrid/Client.java
@@ -345,9 +345,7 @@ public class Client implements Closeable {
 
 	@Override
 	public void close() throws IOException {
-		if(this.createdHttpClient) {
-      this.httpClient.close();
-    }
+      		this.httpClient.close();
 	}
 
 	@Override


### PR DESCRIPTION
`Client` class closes http client by `finalize` method.
However, the method is not promised to be called.

The class should have `close` method to call closing http client expressly.
In additional, we shouldn't call `finalize` method expressly if we want to close the client.

`Closeable` interface supports `try-with-resources Statement`.
https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html
