### PR TITLE
fix: No longer throwing IOExceptions on non 2xx response codes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ gradle.properties
 .gradle
 repo/
 
+# VSCode IDE
+.vscode
+
 # JetBrains IDEs
 *.iml
 **/.idea/

--- a/src/main/java/com/sendgrid/Client.java
+++ b/src/main/java/com/sendgrid/Client.java
@@ -281,12 +281,7 @@ public class Client {
 		try {
 			CloseableHttpResponse serverResponse = httpClient.execute(httpPost);
 			try {
-				Response response = getResponse(serverResponse);
-				if(response.getStatusCode() >= 300) {
-					//throwing IOException here to not break API behavior.
-					throw new IOException("Request returned status Code "+response.getStatusCode()+"Body:"+response.getBody());
-				}
-				return response;
+				return getResponse(serverResponse);
 			} finally {
 				serverResponse.close();
 			}


### PR DESCRIPTION
This fixes issues https://github.com/sendgrid/sendgrid-java/issues/184 and https://github.com/sendgrid/sendgrid-java/issues/212. This was done as part of issue https://github.com/sendgrid/sendgrid-java/issues/221.