### PR TITLE
add whitespace between status code and body for readability

### DIFF
--- a/src/main/java/com/sendgrid/Client.java
+++ b/src/main/java/com/sendgrid/Client.java
@@ -300,7 +300,7 @@ public class Client {
 				Response response = getResponse(serverResponse);
 				if(response.getStatusCode() >= 300) {
 					//throwing IOException here to not break API behavior.
-					throw new IOException("Request returned status Code "+response.getStatusCode()+"Body:"+response.getBody());
+					throw new IOException(String.format("Request returned Status Code: %d, Body: %s", response.getStatusCode(), response.getBody()));
 				}
 				return response;
 			} finally {

--- a/src/test/java/com/sendgrid/ClientTest.java
+++ b/src/test/java/com/sendgrid/ClientTest.java
@@ -174,4 +174,28 @@ public class ClientTest extends Mockito {
   public void testDelete() {
     testMethod(Method.DELETE, 204);
   }
+
+  @Test
+  public void testFailedRequest() {
+    Request request = new Request();
+    request.setMethod(Method.POST);
+    request.setBody("{\"request\":\"body\"}");
+    try {
+      when(statusline.getStatusCode()).thenReturn(400);
+      when(response.getStatusLine()).thenReturn(statusline);
+      when(response.getAllHeaders()).thenReturn(new Header[]{});
+      when(response.getEntity()).thenReturn(
+        new InputStreamEntity(
+          new ByteArrayInputStream(("Bad request").getBytes())));
+      when(httpClient.execute(Matchers.any(HttpPost.class))).thenReturn(response);
+      request.setEndpoint("/test");
+      request.addHeader("Authorization", "Bearer XXXX");
+      Client client = new Client(httpClient);
+      client.api(request);
+      Assert.fail("Exception should be thrown");
+    } catch (IOException ex) {
+      Assert.assertEquals("Request returned Status Code: 400, Body: Bad request", ex.getMessage());
+    }
+  }
+
 }


### PR DESCRIPTION
### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [n/a] I have added necessary documentation about the functionality in the appropriate .md file
- [n/a] I have added in line documentation to the code I modified

### Short description of what this PR does:
Minor change to the format of the error message for cases where executeApiCall results in >= 300 status code.  Adds whitespace between status code and body for readability.

Currently the exception looks like this 
`java.io.IOException: Request returned status Code 400Body:<html>...`
This would update it to:
`java.io.IOException: Request returned Status Code: 400, Body: <html>...`