### PR TITLE
feat!: Upgrading java-http-client to use apache httpclient5

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2023, Twilio SendGrid, Inc. <help@twilio.com>
+Copyright (C) 2024, Twilio SendGrid, Inc. <help@twilio.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/pom.xml
+++ b/pom.xml
@@ -117,14 +117,14 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <version>4.4.15</version>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+      <version>5.2.4</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.13</version>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <version>5.3.1</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/com/sendgrid/Client.java
+++ b/src/main/java/com/sendgrid/Client.java
@@ -27,6 +27,8 @@ import org.apache.hc.client5.http.classic.methods.HttpPut;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 
+import com.sun.jndi.toolkit.url.Uri;
+
 
 /**
  * Class Client allows for quick and easy access any REST or REST-like API.
@@ -97,7 +99,6 @@ public class Client implements Closeable {
 	 */
 	public URI buildUri(String baseUri, String endpoint, Map<String, String> queryParams) throws URISyntaxException {
 		URIBuilder builder = new URIBuilder();
-		URI uri;
 
 		if (this.test) {
 			builder.setScheme("http");
@@ -124,8 +125,7 @@ public class Client implements Closeable {
 				}
 			}
 		}
-		uri = builder.build();
-		return uri;
+		return builder.build();
 	}
 
 
@@ -167,11 +167,8 @@ public class Client implements Closeable {
 	 * @return the response object
 	 */
 	public Response get(Request request) throws URISyntaxException, IOException {
-		URI uri;
-		HttpGet httpGet;
-
-		uri = buildUri(request.getBaseUri(), request.getEndpoint(), request.getQueryParams());
-		httpGet = new HttpGet(uri.toString());
+		URI uri = buildUri(request.getBaseUri(), request.getEndpoint(), request.getQueryParams());
+		HttpGet httpGet = new HttpGet(uri.toString());
 
 		if (request.getHeaders() != null) {
 			for (Map.Entry<String, String> entry : request.getHeaders().entrySet()) {
@@ -195,11 +192,8 @@ public class Client implements Closeable {
 	 * @return the response object
 	 */
 	public Response post(Request request) throws URISyntaxException, IOException {
-		URI uri;
-		HttpPost httpPost;
-
-		uri = buildUri(request.getBaseUri(), request.getEndpoint(), request.getQueryParams());
-		httpPost = new HttpPost(uri.toString());
+		URI uri = buildUri(request.getBaseUri(), request.getEndpoint(), request.getQueryParams());
+		HttpPost httpPost = new HttpPost(uri.toString());
 
 		if (request.getHeaders() != null) {
 			for (Map.Entry<String, String> entry : request.getHeaders().entrySet()) {
@@ -227,11 +221,8 @@ public class Client implements Closeable {
 	 * @return the response object
 	 */
 	public Response patch(Request request) throws URISyntaxException, IOException {
-		URI uri;
-		HttpPatch httpPatch;
-
-		uri = buildUri(request.getBaseUri(), request.getEndpoint(), request.getQueryParams());
-		httpPatch = new HttpPatch(uri.toString());
+		URI uri = buildUri(request.getBaseUri(), request.getEndpoint(), request.getQueryParams());
+		HttpPatch httpPatch = new HttpPatch(uri.toString());
 
 		if (request.getHeaders() != null) {
 			for (Map.Entry<String, String> entry : request.getHeaders().entrySet()) {
@@ -259,11 +250,8 @@ public class Client implements Closeable {
 	 * @return the response object
 	 */
 	public Response put(Request request) throws URISyntaxException, IOException {
-		URI uri;
-		HttpPut httpPut;
-
-		uri = buildUri(request.getBaseUri(), request.getEndpoint(), request.getQueryParams());
-		httpPut = new HttpPut(uri.toString());
+		URI uri = buildUri(request.getBaseUri(), request.getEndpoint(), request.getQueryParams());
+		HttpPut httpPut = new HttpPut(uri.toString());
 
 		if (request.getHeaders() != null) {
 			for (Map.Entry<String, String> entry : request.getHeaders().entrySet()) {
@@ -290,11 +278,8 @@ public class Client implements Closeable {
 	 * @return the response object
 	 */
 	public Response delete(Request request) throws URISyntaxException, IOException {
-		URI uri;
-		BasicClassicHttpRequest httpDelete;
-
-		uri = buildUri(request.getBaseUri(), request.getEndpoint(), request.getQueryParams());
-		httpDelete = new BasicClassicHttpRequest("DELETE", uri.toString());
+		URI uri = buildUri(request.getBaseUri(), request.getEndpoint(), request.getQueryParams());
+		BasicClassicHttpRequest httpDelete = new BasicClassicHttpRequest("DELETE", uri.toString());
 
 		if (request.getHeaders() != null) {
 			for (Map.Entry<String, String> entry : request.getHeaders().entrySet()) {

--- a/src/main/java/com/sendgrid/SendGridResponseHandler.java
+++ b/src/main/java/com/sendgrid/SendGridResponseHandler.java
@@ -2,41 +2,48 @@ package com.sendgrid;
 
 import java.io.IOException;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpResponseException;
-import org.apache.http.impl.client.AbstractResponseHandler;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.impl.classic.AbstractHttpClientResponseHandler;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import java.nio.charset.StandardCharsets;
 
 /**
- * A {@link org.apache.http.client.ResponseHandler} that returns the response body as a String
- * for all responses. 
+ * A {@link org.apache.hc.client5.http.impl.classic.BasicHttpClientResponseHandler} that returns the response body as a
+ * String
+ * for all responses.
  * <p>
  * If this is used with
- * {@link org.apache.http.client.HttpClient#execute(
- *  org.apache.http.client.methods.HttpUriRequest, org.apache.http.client.ResponseHandler)},
+ * {@link org.apache.hc.client5.http.classic.HttpClient#execute(ClassicHttpRequest, HttpClientResponseHandler)}
  * HttpClient may handle redirects (3xx responses) internally.
+ *
  * </p>
  *
  */
-public class SendGridResponseHandler extends AbstractResponseHandler<String>{
+public class SendGridResponseHandler extends AbstractHttpClientResponseHandler<String>{
 
     /**
      * Read the entity from the response body and pass it to the entity handler
      * method if the response was successful (a 2xx status code). If no response
      * body exists, this returns null. If the response was unsuccessful (&gt;= 500
-     * status code), throws an {@link HttpResponseException}.
+     * status code), throws an {@link IOException}.
      */
     @Override
-    public String handleResponse(final HttpResponse response)
-            throws HttpResponseException, IOException {
+    public String handleResponse(final ClassicHttpResponse response)
+    throws IOException {
         final HttpEntity entity = response.getEntity();
         return entity == null ? null : handleEntity(entity);
     }
-	
+
     @Override
-    public String handleEntity(HttpEntity entity) throws IOException {
-        return EntityUtils.toString(entity, StandardCharsets.UTF_8);
+    public String handleEntity(HttpEntity entity) throws IOException{
+        try{
+            return EntityUtils.toString(entity, StandardCharsets.UTF_8);
+        }catch(ParseException e){
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
# Fixes #147

[sendgrid-java](https://github.com/sendgrid/sendgrid-java), specifically the constructor that consumes a [`Client`](https://github.com/sendgrid/sendgrid-java/blob/main/src/main/java/com/sendgrid/SendGrid.java#L34) is currently incompatible with apache httpclient5 due to it's dependency on this repository, a simplified version of the http client. In order for projects on httpclient5 to use sendgrid-java, this dependency needs to be updated first.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/java-http-client/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com), or create a GitHub Issue in this repository.
